### PR TITLE
Add pattern fix

### DIFF
--- a/patterns/defaults/so-it-goes.html
+++ b/patterns/defaults/so-it-goes.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"align":"wide","style":{"color":{"background":"#ffe2c7"}},"className":"wavy-divider-remove-margin wavy-divider-remove-padding"} -->
-<div class="wp-block-group alignwide wavy-divider-remove-margin wavy-divider-remove-padding has-background" style="background-color:#ffe2c7"><!-- wp:spacer {"height":"50px"} -->
-    <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+<div class="wp-block-group alignwide wavy-divider-remove-margin wavy-divider-remove-padding has-background" style="background-color:#ffe2c7"><!-- wp:spacer -->
+    <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
 
     <!-- wp:heading {"textAlign":"center","textColor":"foreground"} -->

--- a/patterns/gradients/acid-burn.html
+++ b/patterns/gradients/acid-burn.html
@@ -1,8 +1,8 @@
 <!-- wp:group {"align":"wide"} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","style":{"color":{"gradient":"linear-gradient(90deg,rgb(235,175,175) 0%,rgb(223,48,197) 51%,rgb(215,46,105) 100%)"}},"className":"wavy-divider-remove-margin wavy-divider-remove-padding"} -->
-    <div class="wp-block-group alignwide wavy-divider-remove-margin wavy-divider-remove-padding has-background" style="background:linear-gradient(90deg,rgb(235,175,175) 0%,rgb(223,48,197) 51%,rgb(215,46,105) 100%)"><!-- wp:spacer {"height":"50px"} -->
-    <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
-    <!-- /wp:spacer -->
+    <div class="wp-block-group alignwide wavy-divider-remove-margin wavy-divider-remove-padding has-background" style="background:linear-gradient(90deg,rgb(235,175,175) 0%,rgb(223,48,197) 51%,rgb(215,46,105) 100%)"><!-- wp:spacer -->
+        <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+        <!-- /wp:spacer -->
 
     <!-- wp:heading {"textAlign":"center","textColor":"foreground"} -->
     <h2 class="has-text-align-center has-foreground-color has-text-color" id="valentine-s-day-event">The beauty of the baud</h2>


### PR DESCRIPTION
The pattern examples were breaking with the Gutenberg plugin disabled. Removing the height attribute from the spacer seems to fix it.